### PR TITLE
Fix menu builder ghost item creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 4.3.3 - 2022-04-12
+### Fixed
+- addGhostItem tried to obtain ID and title trough array access on the object, but this will be looking for
+  children 'id' and 'title' instead of the (extra) properties 'id' and 'title'.
+
 ## 4.3.2 - 2022-04-04
 ### Added
 - Added FQCN service aliases for auto-wiring

--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -338,12 +338,12 @@ class Builder implements ContainerAwareInterface, BuilderInterface
     {
         $item->addChild(
             $this->factory->createItem(
-                $item['id'],
-                array(
+                (string)$item->getExtra('id'),
+                [
                     'uri' => $request->getRequestUri(),
                     'display' => false,
-                    'label' => $item['title']
-                )
+                    'label' => $item->getExtra('title'),
+                ]
             )
         );
     }


### PR DESCRIPTION
The code is accessing the `\Knp\Menu\MenuItem $item` object in array style to fetch `$item['id']` and `$item['title']`. `\Knp\Menu\MenuItem` implements `\ArrayAccess`, but the implementation will check for a child with `$name` through `\Knp\Menu\MenuItem::getChild($name)` which executes `$this->children[$name] ?? null`. A child with name `'id'` or `'title'` doesn't exist, thus it returns `null`.

https://github.com/KnpLabs/KnpMenu/blob/8bd3dc2afa22c65617c563c5e25e62d6e23e98c7/src/Knp/Menu/MenuItem.php#L595-L598

`\Knp\Menu\MenuFactory::createItem()`s first argument `$name` is now typed `string` and thus does not accept `null` as a value. So now that a native PHP type is added somewhere this faulty code errors and this bug is found...