### PR TITLE
Require symfony/security-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 4.3.4 - 2022-05-20
+### Changed
+- Require symfony/security-core instead of bundled package symfony/security
+
 ## 4.3.3 - 2022-04-12
 ### Fixed
 - addGhostItem tried to obtain ID and title trough array access on the object, but this will be looking for

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/console": "^4.4",
         "symfony/dependency-injection": "^4.4",
         "symfony/http-kernel": "^4.4",
-        "symfony/security": "^4.4",
+        "symfony/security-core": "^4.4",
         "twig/twig": "^2.7 || ^3",
         "zicht/admin-bundle": "^6.0",
         "zicht/framework-extra-bundle": "^9.0",


### PR DESCRIPTION
Andere (symfony) packages zouden `symfony/security-core` kunnen requiren en in de knoop kunnen komen door een `symfony/security` requirement. De Menu bundle code gebruikt alleen maar core functionaliteit.