### PR TITLE
Introduced PHP CS Fixer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.github export-ignore

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
             matrix:
-                php: [ '7.2', '7.3', '7.4', '8.0' ]
+                php: [ '7.2', '7.4', '8.0', '8.1' ]
         name: PHP ${{ matrix.php }}
         steps:
             -   uses: actions/checkout@v2
@@ -20,11 +20,13 @@ jobs:
                 with:
                     php-version: ${{ matrix.php }}
                     coverage: none # disable xdebug, pcov
-                    tools: composer:v2
+                    tools: cs2pr
 
             -   run: composer validate --strict
             -   run: composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
             -   run: composer install --prefer-dist --no-progress --no-scripts
+            -   if: always()
+                run: composer run-script lint -- --format=checkstyle | cs2pr
             -   if: always()
                 run: composer run-script test
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.env
 /.idea/
+/.php-cs-fixer.cache
 /.phpunit.result.cache
 /composer.lock
 /docker-compose.y*ml

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__ . '/src')
+    ->in(__DIR__ . '/tests')
+    ->append([__FILE__])
+;
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@Symfony' => true,
+        'blank_line_after_opening_tag' => false,
+        'blank_line_before_statement' => false,
+        'cast_spaces' => ['space' => 'none'],
+        'class_attributes_separation' => ['elements' => ['method' => 'one', 'property' => 'one']],
+        'comment_to_phpdoc' => [],
+        'concat_space' => ['spacing' => 'one'],
+        'declare_strict_types' => false,
+        'linebreak_after_opening_tag' => false,
+        'no_superfluous_phpdoc_tags' => ['allow_mixed' => true, 'allow_unused_params' => false],
+        'ordered_class_elements' => ['order' => ['use_trait', 'constant', 'property', 'construct']],
+        'phpdoc_add_missing_param_annotation' => ['only_untyped' => true],
+        'phpdoc_align' => false,
+        'phpdoc_annotation_without_dot' => false,
+        'phpdoc_separation' => false,
+        'phpdoc_summary' => false,
+        'phpdoc_to_comment' => ['ignored_tags' => ['var', 'see', 'todo', 'psalm-suppress']],
+        'protected_to_private' => false,
+        'yoda_style' => false,
+        'visibility_required' => ['elements' => ['property', 'method']],
+    ])
+    ->setFinder($finder)
+;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 5.0.5 - 2022-10-01
+### Changed
+- Introduced PHP CS Fixer.
+- Removed PHP 7.3 and added PHP 8.1 to the GitHub actions PHP versions matrix.
+- Additional cleanup.
+- Remove suggests from composer.json
+
 ## 5.0.4 - 2022-05-20
 ### Changed
 - Forward merge of v4.3.4: Require symfony/security-core instead of bundled package symfony/security

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,6 @@
         "zicht/framework-extra-bundle": "^9.0",
         "zicht/url-bundle": "^5.0"
     },
-    "suggest": {
-        "zicht/admin-bundle": "To integrate with Sonata Admin",
-        "zicht/status-bundle": "To integrate status-checks"
-    },
     "require-dev": {
         "phpunit/phpunit": "^8"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "zicht/url-bundle": "^5.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3",
         "phpunit/phpunit": "^8"
     },
     "autoload": {
@@ -41,8 +42,8 @@
     "minimum-stability": "stable",
     "license": "MIT",
     "scripts": {
-        "test": [
-            "phpunit -c phpunit.xml.dist"
-        ]
+        "lint": "php-cs-fixer fix --dry-run --diff -vvv",
+        "lint-fix": "php-cs-fixer fix",
+        "test": "phpunit"
     }
 }

--- a/src/Admin/Extension/TreeAdminExtension.php
+++ b/src/Admin/Extension/TreeAdminExtension.php
@@ -8,9 +8,6 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class TreeAdminExtension extends AbstractAdminExtension
 {
-    /**
-     * {@inheritDoc}
-     */
     public function configureFormFields(FormMapper $formMapper)
     {
         $subject = $formMapper->getAdmin()->getSubject();

--- a/src/Admin/MenuItemAdmin.php
+++ b/src/Admin/MenuItemAdmin.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
+
 namespace Zicht\Bundle\MenuBundle\Admin;
 
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
@@ -12,16 +12,8 @@ use Zicht\Bundle\AdminBundle\Admin\TreeAdmin;
 use Zicht\Bundle\MenuBundle\Security\Authorization\MenuVoter;
 use Zicht\Bundle\UrlBundle\Type\UrlType;
 
-/**
- * Class MenuItemAdmin
- *
- * @package Zicht\Bundle\MenuBundle\Admin
- */
 class MenuItemAdmin extends TreeAdmin
 {
-    /**
-     * @{inheritDoc}
-     */
     public function configureFormFields(FormMapper $formMapper)
     {
         parent::configureFormFields($formMapper);
@@ -29,25 +21,21 @@ class MenuItemAdmin extends TreeAdmin
         $formMapper
             ->tab('admin.tab.menu_item')
                 ->with('admin.tab.menu_item')
-                    ->add('path', UrlType::class, array('required' => false))
+                    ->add('path', UrlType::class, ['required' => false])
                     ->add(
                         'name',
                         null,
-                        array(
+                        [
                             'label' => 'form.label_name_technical',
                             'attr' => ['read_only' => !$this->hasNameFieldAccess()],
-                            'disabled'  => !$this->hasNameFieldAccess(),
-                            'help' => 'admin.help.menu_item_name'
-                        )
+                            'disabled' => !$this->hasNameFieldAccess(),
+                            'help' => 'admin.help.menu_item_name',
+                        ]
                     )
                 ->end()
             ->end();
-        ;
     }
 
-    /**
-     * @{inheritDoc}
-     */
     public function configureListFields(ListMapper $listMapper)
     {
         parent::configureListFields($listMapper);
@@ -61,9 +49,6 @@ class MenuItemAdmin extends TreeAdmin
         );
     }
 
-    /**
-     * @param DatagridMapper $filter
-     */
     protected function configureDatagridFilters(DatagridMapper $filter)
     {
         parent::configureDatagridFilters($filter);

--- a/src/Command/PublicToInternalUriCommand.php
+++ b/src/Command/PublicToInternalUriCommand.php
@@ -1,7 +1,6 @@
 <?php
 
 /**
- * @author Muhammed Akbulut <muhammed@zicht.nl>
  * @copyright Zicht Online <http://www.zicht.nl>
  */
 
@@ -14,23 +13,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command class for replacing public menu URI’s with internal ones.
- *
- * @package Zicht\Bundle\MenuBundle\Command
  */
 class PublicToInternalUriCommand extends Command
 {
-    /**
-     * @var EntityManagerInterface $entityManager
-     */
+    /** @var EntityManagerInterface */
     protected $entityManager;
 
     protected static $defaultName = 'zicht:menu:public-to-internal';
 
-    /**
-     * Initializes a new instance of the PublicToInternalUriCommand class.
-     *
-     * @param EntityManagerInterface $entityManager
-     */
     public function __construct(EntityManagerInterface $entityManager)
     {
         parent::__construct();
@@ -38,21 +28,12 @@ class PublicToInternalUriCommand extends Command
         $this->entityManager = $entityManager;
     }
 
-
-    /**
-     * {@inheritdoc}
-     */
     protected function configure()
     {
-        $this
-            ->setDescription('Convert public menu URI’s to internal URI’s');
+        $this->setDescription('Convert public menu URI’s to internal URI’s');
     }
 
     /**
-     * Execute
-     *
-     * @param InputInterface $input
-     * @param OutputInterface $output
      * @throws \Exception
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/DependencyInjection/CompilerPass/SetPreloadMenusPass.php
+++ b/src/DependencyInjection/CompilerPass/SetPreloadMenusPass.php
@@ -1,9 +1,7 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
-
 
 namespace Zicht\Bundle\MenuBundle\DependencyInjection\CompilerPass;
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -8,12 +8,8 @@ namespace Zicht\Bundle\MenuBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-/**
- * Config for menu bundle.
- */
 class Configuration implements ConfigurationInterface
 {
-    /** {@inheritDoc} */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('zicht_menu');

--- a/src/DependencyInjection/ZichtMenuExtension.php
+++ b/src/DependencyInjection/ZichtMenuExtension.php
@@ -1,43 +1,33 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht online <http://zicht.nl>
  */
 
 namespace Zicht\Bundle\MenuBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-/**
- * This is the class that loads and manages your bundle configuration
- *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
- */
 class ZichtMenuExtension extends Extension
 {
-    /**
-     * {@inheritDoc}
-     */
     public function load(array $configs, ContainerBuilder $container)
     {
-
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('zicht_menu.builder_service', $config['builder_service']);
         $container->setParameter('zicht_menu.preload_menus', $config['menus']);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
         $loader->load('admin.xml');
 
         $formResources = $container->getParameter('twig.form.resources');
-        $formResources[]= '@ZichtMenu/form_theme.html.twig';
+        $formResources[] = '@ZichtMenu/form_theme.html.twig';
         $container->setParameter('twig.form.resources', $formResources);
 
         $container->getDefinition('zicht_menu.provider.database_menu_provider')->replaceArgument(0, new Reference($config['builder_service']));

--- a/src/Entity/MenuItem.php
+++ b/src/Entity/MenuItem.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Muhammed Akbulut <muhammed@zicht.nl>
  * @copyright Zicht Online <http://www.zicht.nl>
  */
 
@@ -12,8 +11,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
- * Zicht\Bundle\MenuBundle\Entity\MenuItem
- *
  * @ORM\Entity
  * @ORM\Table(
  *      name="menu_item",
@@ -29,7 +26,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 class MenuItem
 {
     /**
-     * @var integer $id
+     * @var int
      *
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id
@@ -75,7 +72,7 @@ class MenuItem
     private $children;
 
     /**
-     * @var string $title
+     * @var string
      *
      * @ORM\Column(name="title", type="string", length=255)
      */
@@ -87,7 +84,7 @@ class MenuItem
     private $language = null;
 
     /**
-     * @var string $path
+     * @var string
      *
      * @ORM\Column(name="path", type="string", length=255, nullable=true)
      */
@@ -107,9 +104,10 @@ class MenuItem
      */
     private $json_data = null;
 
+    /** @var bool */
+    protected $addToMenu = false;
+
     /**
-     * MenuItem constructor.
-     *
      * @param null $title
      * @param null $path
      * @param string $name
@@ -124,9 +122,7 @@ class MenuItem
     }
 
     /**
-     * Get id
-     *
-     * @return integer
+     * @return int
      */
     public function getId()
     {
@@ -134,8 +130,6 @@ class MenuItem
     }
 
     /**
-     * Set title
-     *
      * @param string $title
      * @return MenuItem
      */
@@ -146,8 +140,6 @@ class MenuItem
     }
 
     /**
-     * Get title
-     *
      * @return string
      */
     public function getTitle()
@@ -164,8 +156,6 @@ class MenuItem
     }
 
     /**
-     * Set path
-     *
      * @param string $path
      * @return MenuItem
      */
@@ -177,8 +167,6 @@ class MenuItem
     }
 
     /**
-     * Get path
-     *
      * @return string
      */
     public function getPath()
@@ -187,8 +175,6 @@ class MenuItem
     }
 
     /**
-     * Set parent
-     *
      * @param MenuItem $parent
      * @return MenuItem
      */
@@ -200,8 +186,6 @@ class MenuItem
     }
 
     /**
-     * Get parent
-     *
      * @return MenuItem
      */
     public function getParent()
@@ -210,9 +194,6 @@ class MenuItem
     }
 
     /**
-     * Add children
-     *
-     * @param MenuItem $children
      * @return MenuItem
      * @deprecated addChildren (i.e. plural) is confusing, use addChild instead
      */
@@ -222,9 +203,6 @@ class MenuItem
     }
 
     /**
-     * Add a child menu item
-     *
-     * @param MenuItem $child
      * @return $this
      */
     public function addChild(MenuItem $child)
@@ -234,9 +212,6 @@ class MenuItem
     }
 
     /**
-     * Remove children
-     *
-     * @param MenuItem $children
      * @deprecated removeChildren (i.e. plural) is confusing, use removeChild instead
      */
     public function removeChildren(MenuItem $children)
@@ -245,9 +220,6 @@ class MenuItem
     }
 
     /**
-     * Remove a child menu item
-     *
-     * @param MenuItem $child
      * @return $this
      */
     public function removeChild(MenuItem $child)
@@ -257,8 +229,6 @@ class MenuItem
     }
 
     /**
-     * Get children
-     *
      * @return Collection
      */
     public function getChildren()
@@ -275,9 +245,7 @@ class MenuItem
     }
 
     /**
-     * Set lft
-     *
-     * @param integer $lft
+     * @param int $lft
      * @return MenuItem
      */
     public function setLft($lft)
@@ -288,9 +256,7 @@ class MenuItem
     }
 
     /**
-     * Get lft
-     *
-     * @return integer
+     * @return int
      */
     public function getLft()
     {
@@ -298,9 +264,7 @@ class MenuItem
     }
 
     /**
-     * Set lvl
-     *
-     * @param integer $lvl
+     * @param int $lvl
      * @return MenuItem
      */
     public function setLvl($lvl)
@@ -311,9 +275,7 @@ class MenuItem
     }
 
     /**
-     * Get lvl
-     *
-     * @return integer
+     * @return int
      */
     public function getLvl()
     {
@@ -330,9 +292,7 @@ class MenuItem
     }
 
     /**
-     * Set rgt
-     *
-     * @param integer $rgt
+     * @param int $rgt
      * @return MenuItem
      */
     public function setRgt($rgt)
@@ -343,9 +303,7 @@ class MenuItem
     }
 
     /**
-     * Get rgt
-     *
-     * @return integer
+     * @return int
      */
     public function getRgt()
     {
@@ -353,9 +311,7 @@ class MenuItem
     }
 
     /**
-     * Set root
-     *
-     * @param integer $root
+     * @param int $root
      * @return MenuItem
      */
     public function setRoot($root)
@@ -366,15 +322,12 @@ class MenuItem
     }
 
     /**
-     * Get root
-     *
-     * @return integer
+     * @return int
      */
     public function getRoot()
     {
         return $this->root;
     }
-
 
     /**
      * @return bool
@@ -384,7 +337,6 @@ class MenuItem
         return $this->root == $this->id;
     }
 
-
     /**
      * @param string $name
      */
@@ -393,7 +345,6 @@ class MenuItem
         $this->name = $name;
     }
 
-
     /**
      * @return null
      */
@@ -401,12 +352,6 @@ class MenuItem
     {
         return $this->name;
     }
-
-
-    /**
-     * @var bool
-     */
-    protected $addToMenu = false;
 
     /**
      * @param bool $addToMenu
@@ -454,7 +399,7 @@ class MenuItem
     public function getJsonData()
     {
         if (!$this->json_data) {
-            return array();
+            return [];
         }
         return $this->json_data;
     }

--- a/src/Form/MenuItemType.php
+++ b/src/Form/MenuItemType.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
 
@@ -14,28 +13,16 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Zicht\Bundle\FrameworkExtraBundle\Form\ParentChoiceType;
 use Zicht\Bundle\UrlBundle\Url\Provider;
 
-/**
- * Class MenuItemType
- *
- * @package Zicht\Bundle\MenuBundle\Form
- */
 class MenuItemType extends AbstractType
 {
-    /**
-     * @var object
-     */
+    /** @var object */
     protected $menuManager;
 
-    /**
-     * @var Provider
-     */
+    /** @var Provider */
     protected $urlProvider;
 
     /**
-     * MenuItemType constructor.
-     *
      * @param object $menuManager
-     * @param Provider $urlProvider
      */
     public function __construct($menuManager, Provider $urlProvider)
     {
@@ -43,49 +30,27 @@ class MenuItemType extends AbstractType
         $this->urlProvider = $urlProvider;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
             ->setDefaults(
-                array(
+                [
                     'mapped' => false,
                     'data_class' => 'Zicht\Bundle\MenuBundle\Entity\MenuItem',
-                )
+                ]
             );
     }
 
-    /**
-     * Build form
-     *
-     * @param FormBuilderInterface $builder
-     * @param array $options
-     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         parent::buildForm($builder, $options);
 
         $builder
-            ->add('add_to_menu', CheckboxType::class, array('required' => false, 'label' => 'form.label_add_to_menu'))
-            ->add('parent', ParentChoiceType::class, array('class' => 'Zicht\Bundle\MenuBundle\Entity\MenuItem', 'label' => 'form.label_parent'))
-            ->add('title', TextType::class, array('required' => false, 'label' => 'form.label_title'));
+            ->add('add_to_menu', CheckboxType::class, ['required' => false, 'label' => 'form.label_add_to_menu'])
+            ->add('parent', ParentChoiceType::class, ['class' => 'Zicht\Bundle\MenuBundle\Entity\MenuItem', 'label' => 'form.label_parent'])
+            ->add('title', TextType::class, ['required' => false, 'label' => 'form.label_title']);
     }
 
-    /**
-     * Returns the name of this type.
-     *
-     * @return string The name of this type
-     */
-    public function getName()
-    {
-        return 'zicht_menu_item';
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function getBlockPrefix()
     {
         return 'zicht_menu_item';

--- a/src/Form/Subscriber/MenuItemPersistenceSubscriber.php
+++ b/src/Form/Subscriber/MenuItemPersistenceSubscriber.php
@@ -1,39 +1,19 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
+
 namespace Zicht\Bundle\MenuBundle\Form\Subscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Zicht\Bundle\MenuBundle\Manager\MenuManager;
 use Zicht\Bundle\UrlBundle\Url\Provider;
 
-/**
- * Class MenuItemPersistenceSubscriber
- *
- * @package Zicht\Bundle\MenuBundle\Form\Subscriber
- */
 class MenuItemPersistenceSubscriber implements EventSubscriberInterface
 {
     /**
-     * @{inheritDoc}
-     */
-    public static function getSubscribedEvents()
-    {
-        return array(
-            FormEvents::POST_SET_DATA   => 'postSetData',
-            FormEvents::POST_SUBMIT     => 'postSubmit'
-        );
-    }
-
-    /**
-     * Constructor
-     *
-     * @param MenuManager $mm
-     * @param Provider $provider
      * @param string $property
      */
     public function __construct(MenuManager $mm, Provider $provider, $property)
@@ -43,13 +23,15 @@ class MenuItemPersistenceSubscriber implements EventSubscriberInterface
         $this->property = $property;
     }
 
-    /**
-     * POST_SET_DATA event handler
-     *
-     * @param FormEvent $e
-     * @return void
-     */
-    public function postSetData(FormEvent $e)
+    public static function getSubscribedEvents()
+    {
+        return [
+            FormEvents::POST_SET_DATA => 'postSetData',
+            FormEvents::POST_SUBMIT => 'postSubmit',
+        ];
+    }
+
+    public function postSetData(FormEvent $e): void
     {
         if ($e->getData() === null) {
             return;
@@ -61,20 +43,14 @@ class MenuItemPersistenceSubscriber implements EventSubscriberInterface
             return;
         }
         if ($this->provider->supports($e->getData())) {
-            if ($item = $this->mm->getItemBy(array(':path' => $this->provider->url($e->getData())))) {
+            if ($item = $this->mm->getItemBy([':path' => $this->provider->url($e->getData())])) {
                 $item->setAddToMenu(true);
                 $e->getForm()->get($this->property)->setData($item);
             }
         }
     }
 
-    /**
-     * POST_SUBMIT handler
-     *
-     * @param FormEvent $e
-     * @return void
-     */
-    public function postSubmit(FormEvent $e)
+    public function postSubmit(FormEvent $e): void
     {
         if ($e->getForm()->has($this->property) && $e->getForm()->getRoot()->isValid()) {
             $menuItem = $e->getForm()->get($this->property)->getData();
@@ -83,7 +59,7 @@ class MenuItemPersistenceSubscriber implements EventSubscriberInterface
                 if (!$menuItem->getTitle()) {
                     $menuItem->setTitle((string)$e->getData());
                 }
-                $menuItem->setPath($this->provider->url($e->getData(), array('aliasing' => false)));
+                $menuItem->setPath($this->provider->url($e->getData(), ['aliasing' => false]));
                 $this->mm->addItem($menuItem);
             } elseif ($menuItem->getId()) {
                 $this->mm->removeItem($menuItem);

--- a/src/Menu/BuilderInterface.php
+++ b/src/Menu/BuilderInterface.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @author Rik van der Kemp <rik@zicht.nl>
  * @copyright Zicht Online <http://www.zicht.nl>
  */
+
 namespace Zicht\Bundle\MenuBundle\Menu;
 
 use InvalidArgumentException;
@@ -10,17 +10,9 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuItem;
 use Symfony\Component\HttpFoundation\Request;
 
-
-/**
- * Class Builder
- *
- * @package Zicht\Bundle\MenuBundle\Menu
- */
 interface BuilderInterface
 {
     /**
-     * Set the menu names to preload
-     *
      * @param array $menus
      */
     public function setPreloadMenus($menus);
@@ -29,9 +21,7 @@ interface BuilderInterface
      * Create the menu based on the doctrine model.
      *
      * @param string $name
-     * @param \Symfony\Component\HttpFoundation\Request $request
      * @return ItemInterface
-     *
      * @throws \InvalidArgumentException
      */
     public function build($name, Request $request);
@@ -46,8 +36,6 @@ interface BuilderInterface
     public function getRootItemByName($name, $request);
 
     /**
-     * Check if a root item exists.
-     *
      * @param string $name
      * @param Request $request
      * @return bool
@@ -55,8 +43,6 @@ interface BuilderInterface
     public function hasRootItemByName($name, $request);
 
     /**
-     * Create menu
-     *
      * @param Request $request
      * @param ItemInterface $root
      * @return ItemInterface
@@ -65,8 +51,6 @@ interface BuilderInterface
     public function createMenu($request, $root);
 
     /**
-     * Add menu item hierarchy
-     *
      * @param Request $request
      * @param mixed $children
      * @param ItemInterface $parent
@@ -77,10 +61,6 @@ interface BuilderInterface
     /**
      * Utility method to convert MenuItem's from the doctrine model to Knp MenuItems
      *
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param array $item
-     * @param MenuItem $menu
-     *
      * @return ItemInterface
      */
     public function addMenuItem(Request $request, array $item, MenuItem $menu);
@@ -88,7 +68,6 @@ interface BuilderInterface
     /**
      * Adds an item on the fly that was not originally in the menu.
      *
-     * @param \Symfony\Component\HttpFoundation\Request $request
      * @param ItemInterface $item
      * @return void
      */

--- a/src/Menu/UrlAliasingAwareBuilder.php
+++ b/src/Menu/UrlAliasingAwareBuilder.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
 
@@ -10,9 +9,6 @@ use Doctrine\Bundle\DoctrineBundle\Registry;
 use Knp\Menu\FactoryInterface;
 
 /**
- * Class UrlAliasingAwareBuilder
- *
- * @package Zicht\Bundle\MenuBundle\Menu
  * @deprecated The aliasing is now delegated to a response listener in the UrlBundle. Extend the regular Builder in stead
  */
 class UrlAliasingAwareBuilder extends Builder
@@ -20,7 +16,6 @@ class UrlAliasingAwareBuilder extends Builder
     /**
      * Overridden to provide a DEPRECATED warning
      *
-     * @param FactoryInterface $factory
      * @param Registry $doctrine
      * @param string $entity
      */

--- a/src/Provider/DatabaseMenuProvider.php
+++ b/src/Provider/DatabaseMenuProvider.php
@@ -8,26 +8,19 @@ namespace Zicht\Bundle\MenuBundle\Provider;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\MatcherInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Zicht\Bundle\MenuBundle\Menu\Builder;
 use Zicht\Bundle\MenuBundle\Menu\BuilderInterface;
 
 class DatabaseMenuProvider implements MenuProviderInterface
 {
-    /**
-     * @var Builder
-     */
+    /** @var Builder */
     protected $builder = null;
 
-    /**
-     * @var RequestStack
-     */
+    /** @var RequestStack */
     protected $requestStack;
 
-    /**
-     * @var MatcherInterface
-     */
+    /** @var MatcherInterface */
     protected $matcher;
 
     public function __construct(BuilderInterface $builder, RequestStack $requestStack, MatcherInterface $matcher)
@@ -37,9 +30,6 @@ class DatabaseMenuProvider implements MenuProviderInterface
         $this->matcher = $matcher;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function get(string $name, array $options = []): ItemInterface
     {
         $menu = $this->builder->build($name, $this->requestStack->getCurrentRequest());
@@ -51,9 +41,6 @@ class DatabaseMenuProvider implements MenuProviderInterface
         return $menu;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function has(string $name, array $options = []): bool
     {
         $root = $this->builder->hasRootItemByName($name, $this->requestStack->getCurrentRequest());

--- a/src/Security/Authorization/MenuVoter.php
+++ b/src/Security/Authorization/MenuVoter.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * @author    Philip Bergman <philip@zicht.nl>
- * @copyright Zicht Online <http://www.zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\MenuBundle\Security\Authorization;
@@ -11,57 +10,36 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 use Zicht\Bundle\MenuBundle\Entity\MenuItem;
 
-/**
- * Class MenuVoter
- *
- * @package Zicht\Bundle\MenuBundle\Security\Authorization
- */
 class MenuVoter implements VoterInterface
 {
     /**
      * The role name to use for having access to the admin menu
      */
-    const ROLE_ADMIN_MENU_ITEM = "ROLE_ADMIN_MENU_ITEM";
+    const ROLE_ADMIN_MENU_ITEM = 'ROLE_ADMIN_MENU_ITEM';
 
     /**
      * Whether the user has access to the 'name' field.
      */
-    const ROLE_NAME_FIELD_ACCESS = "ROLE_NAME_FIELD_ACCESS";
+    const ROLE_NAME_FIELD_ACCESS = 'ROLE_NAME_FIELD_ACCESS';
 
-    /**
-     * @var RoleHierarchyInterface
-     */
+    /** @var RoleHierarchyInterface */
     protected $hierarchy;
 
-    /**
-     * Constructor
-     *
-     * @param RoleHierarchyInterface $hierarchy
-     */
     public function __construct(RoleHierarchyInterface $hierarchy)
     {
         $this->hierarchy = $hierarchy;
     }
 
-    /**
-     * @{inheritDoc}
-     */
     public function supportsAttribute($attribute)
     {
-        return in_array($attribute, array('DELETE', self::ROLE_NAME_FIELD_ACCESS));
+        return in_array($attribute, ['DELETE', self::ROLE_NAME_FIELD_ACCESS]);
     }
 
-    /**
-     * @{inheritDoc}
-     */
     public function supportsClass($class)
     {
         return $class === MenuItem::class;
     }
 
-    /**
-     * @{inheritDoc}
-     */
     public function vote(TokenInterface $token, $object, array $attributes)
     {
         foreach ($attributes as $attribute) {
@@ -89,7 +67,6 @@ class MenuVoter implements VoterInterface
     /**
      * Calculate whether the current token is allowed.
      *
-     * @param TokenInterface $token
      * @return  bool
      */
     protected function userIsAllowed(TokenInterface $token)

--- a/src/StatusProvider/ValidateNestedTreeProvider.php
+++ b/src/StatusProvider/ValidateNestedTreeProvider.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * @author Boudewijn Schoon <boudewijn@zicht.nl>
- * @copyright Zicht Online <http://zicht.nl>
+ * @copyright Zicht Online <https://zicht.nl>
  */
 
 namespace Zicht\Bundle\MenuBundle\StatusProvider;
@@ -16,11 +15,6 @@ class ValidateNestedTreeProvider extends StatusProviderHelper implements StatusP
     /** @var ManagerRegistry */
     private $doctrine;
 
-    /**
-     * ValidateNestedTreeProvider constructor.
-     *
-     * @param ManagerRegistry $doctrine
-     */
     public function __construct(ManagerRegistry $doctrine)
     {
         $this->doctrine = $doctrine;
@@ -37,33 +31,21 @@ class ValidateNestedTreeProvider extends StatusProviderHelper implements StatusP
         return [false, ['error_count' => count($result)]];
     }
 
-    /**
-     * @{inheritDoc}
-     */
     public function getGroup()
     {
         return 'Menu bundle';
     }
 
-    /**
-     * @{inheritDoc}
-     */
     public function getOrder()
     {
         return 0;
     }
 
-    /**
-     * @{inheritDoc}
-     */
     public function getName()
     {
         return 'Nested tree status';
     }
 
-    /**
-     * @{inheritDoc}
-     */
     public function getDescription()
     {
         return sprintf('Check that the menu stored in entity "%s" is valid', MenuItem::class);

--- a/src/Twig/Extension.php
+++ b/src/Twig/Extension.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
 
@@ -13,28 +12,14 @@ use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 
-/**
- * Class Extension
- *
- * @package Zicht\Bundle\MenuBundle\Twig
- */
 class Extension extends AbstractExtension
 {
-    /**
-     * @var MenuProviderInterface
-     */
+    /** @var MenuProviderInterface */
     private $menuProvider;
 
-    /**
-     * @var MatcherInterface
-     */
+    /** @var MatcherInterface */
     private $matcher;
 
-    /**
-     * Constructor
-     *
-     * @param MenuProviderInterface $menuProvider
-     */
     public function __construct(MenuProviderInterface $menuProvider)
     {
         $this->menuProvider = $menuProvider;
@@ -64,15 +49,13 @@ class Extension extends AbstractExtension
      */
     public function getFunctions()
     {
-        return array(
+        return [
             'zicht_menu_active_trail' => new TwigFunction('zicht_menu_active_trail', [$this, 'activeTrail']),
-            'zicht_menu_exists' => new TwigFunction('zicht_menu_exists', [$this, 'exists'])
-        );
+            'zicht_menu_exists' => new TwigFunction('zicht_menu_exists', [$this, 'exists']),
+        ];
     }
 
     /**
-     * Returns if the given menuName exists
-     *
      * @param string $menuName
      * @return bool
      */
@@ -82,11 +65,8 @@ class Extension extends AbstractExtension
     }
 
     /**
-     * Returns the active trail for the given menuItem
-     *
      * @param MenuItem|null $item
      * @return array
-     *
      */
     public function activeTrail($item)
     {
@@ -98,7 +78,7 @@ class Extension extends AbstractExtension
             throw new \UnexpectedValueException(sprintf('$ITEM must be \Knp\Menu\MenuItem not "%s"', get_class($item)));
         }
 
-        $stack = array();
+        $stack = [];
 
         do {
             $stack[] = $item;
@@ -108,8 +88,6 @@ class Extension extends AbstractExtension
     }
 
     /**
-     * Returns the current menu item given a root menu item
-     *
      * @param MenuItem|null $item
      * @param int $level
      * @return MenuItem|null
@@ -146,15 +124,5 @@ class Extension extends AbstractExtension
         }
 
         return null;
-    }
-
-    /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
-    {
-        return 'zicht_menu';
     }
 }

--- a/src/Url/AliasingStrategy.php
+++ b/src/Url/AliasingStrategy.php
@@ -1,39 +1,27 @@
 <?php
 /**
- * @author Rik van der Kemp <rik@zicht.nl>
  * @copyright Zicht Online <http://www.zicht.nl>
  */
+
 namespace Zicht\Bundle\MenuBundle\Url;
 
 use Zicht\Bundle\MenuBundle\Manager\MenuManager;
 use Zicht\Bundle\UrlBundle\Aliasing\DefaultAliasingStrategy;
+use Zicht\Bundle\UrlBundle\Aliasing\ProviderDecorator;
 use Zicht\Bundle\UrlBundle\Url\Provider;
 use Zicht\Util\Str;
 
 /**
- * Menu AliasingStrategy
- *
  * Creates aliases based on the menu
- *
- * @package Zicht\Bundle\MenuBundle\Url
  */
 class AliasingStrategy extends DefaultAliasingStrategy
 {
-    /**
-     * @var \Zicht\Bundle\MenuBundle\Manager\MenuManager
-     */
+    /** @var MenuManager */
     private $menuManager;
-    /**
-     * @var \Zicht\Bundle\UrlBundle\Aliasing\ProviderDecorator
-     */
+
+    /** @var ProviderDecorator */
     private $urlProvider;
 
-    /**
-     * AliasingStrategy constructor.
-     *
-     * @param MenuManager $menuManager
-     * @param Provider $urlProvider
-     */
     public function __construct(MenuManager $menuManager, Provider $urlProvider)
     {
         parent::__construct('/');
@@ -42,8 +30,6 @@ class AliasingStrategy extends DefaultAliasingStrategy
     }
 
     /**
-     * Generate a public alias for the passed object
-     *
      * @param mixed $subject
      * @param string $currentAlias
      * @return string
@@ -51,11 +37,11 @@ class AliasingStrategy extends DefaultAliasingStrategy
     public function generatePublicAlias($subject, $currentAlias = '')
     {
         $path = $this->urlProvider->url($subject);
-        $menuItem = $this->menuManager->getItemBy(array(':path' => $path));
+        $menuItem = $this->menuManager->getItemBy([':path' => $path]);
         if (!empty($menuItem)) {
-            $parts = array();
+            $parts = [];
             for ($item = $menuItem; !is_null($item->getParent()); $item = $item->getParent()) {
-                $parts [] = Str::systemize($item->getTitle());
+                $parts[] = Str::systemize($item->getTitle());
             }
             $alias = '/' . join('/', array_reverse($parts));
         } else {

--- a/src/Url/MenuItemNameUrlProvider.php
+++ b/src/Url/MenuItemNameUrlProvider.php
@@ -1,34 +1,21 @@
 <?php
 /**
- * @author Gerard van Helden <gerard@zicht.nl>
  * @copyright Zicht Online <http://zicht.nl>
  */
 
 namespace Zicht\Bundle\MenuBundle\Url;
 
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\ORM\EntityRepository;
+use Symfony\Component\Routing\RouterInterface;
 use Zicht\Bundle\UrlBundle\Url\StaticProvider;
 use Zicht\Bundle\UrlBundle\Url\SuggestableProvider;
-use Doctrine\Bundle\DoctrineBundle\Registry;
-use Symfony\Component\Routing\RouterInterface;
 
-/**
- * Class MenuItemNameUrlProvider
- *
- * @package Zicht\Bundle\MenuBundle\Url
- */
 class MenuItemNameUrlProvider extends StaticProvider implements SuggestableProvider
 {
-    /**
-     * @var \Doctrine\ORM\EntityRepository
-     */
+    /** @var EntityRepository */
     private $repository;
 
-    /**
-     * MenuItemNameUrlProvider constructor.
-     *
-     * @param Registry $doctrine
-     * @param RouterInterface $router
-     */
     public function __construct(Registry $doctrine, RouterInterface $router)
     {
         parent::__construct($router);
@@ -38,8 +25,6 @@ class MenuItemNameUrlProvider extends StaticProvider implements SuggestableProvi
     }
 
     /**
-     * If it supports the given name
-     *
      * @param mixed $name
      * @return bool|mixed
      */
@@ -94,14 +79,14 @@ class MenuItemNameUrlProvider extends StaticProvider implements SuggestableProvi
         $menuItems = $this->repository->createQueryBuilder('m')
             ->andWhere('m.name LIKE :pattern')
             ->getQuery()
-            ->execute(array('pattern' => '%' . $pattern . '%'));
+            ->execute(['pattern' => '%' . $pattern . '%']);
 
-        $suggestions = array();
+        $suggestions = [];
         foreach ($menuItems as $item) {
-            $suggestions[]= array(
+            $suggestions[] = [
                 'value' => $item->getName(),
-                'label' => sprintf('%s (menu item)', $item)
-            );
+                'label' => sprintf('%s (menu item)', $item),
+            ];
         }
 
         return $suggestions;

--- a/src/Voter/UriVoter.php
+++ b/src/Voter/UriVoter.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Rik van der Kemp <rik@zicht.nl>
  * @copyright Zicht Online <http://www.zicht.nl>
  */
 
@@ -11,32 +10,20 @@ use Knp\Menu\Matcher\Voter\VoterInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * Class UriVoter.
- *
  * Simple UriVoter, checks the master request for the current PathInfo and matches against current item.
  */
 class UriVoter implements VoterInterface
 {
-    /**
-     * @var RequestStack
-     */
+    /** @var RequestStack */
     protected $requestStack;
 
-    /**
-     * UriVoter constructor.
-     *
-     * @param RequestStack $requestStack
-     */
     public function __construct(RequestStack $requestStack)
     {
         $this->requestStack = $requestStack;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function matchItem(ItemInterface $item): ?bool
     {
-        return ($this->requestStack->getMasterRequest()->getPathInfo() === $item->getUri() ? true : null);
+        return $this->requestStack->getMasterRequest()->getPathInfo() === $item->getUri() ? true : null;
     }
 }

--- a/src/ZichtMenuBundle.php
+++ b/src/ZichtMenuBundle.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Muhammed Akbulut <muhammed@zicht.nl>
  * @copyright Zicht Online <http://www.zicht.nl>
  */
 
@@ -9,11 +8,6 @@ namespace Zicht\Bundle\MenuBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * Class ZichtMenuBundle
- *
- * @package Zicht\Bundle\MenuBundle
- */
 class ZichtMenuBundle extends Bundle
 {
     public function build(ContainerBuilder $container)

--- a/tests/Entity/MenuItemTest.php
+++ b/tests/Entity/MenuItemTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * For licensing information, please see the LICENSE file accompanied with this file.
- *
- * @author Gerard van Helden <drm@melp.nl>
- * @copyright 2012 Gerard van Helden <http://melp.nl>
+ * @copyright Zicht Online <http://zicht.nl>
  */
+
 namespace ZichtTest\Bundle\MenuBundle\Entity;
 
 use PHPUnit\Framework\TestCase;
@@ -12,7 +10,7 @@ use Zicht\Bundle\MenuBundle\Entity\MenuItem;
 
 class MenuItemTest extends TestCase
 {
-    function testGettersSetters()
+    public function testGettersSetters()
     {
         $refl = new \ReflectionClass('Zicht\Bundle\MenuBundle\Entity\MenuItem');
 
@@ -21,9 +19,9 @@ class MenuItemTest extends TestCase
             $name = $method->getName();
             if (substr($name, 0, 3) === 'set') {
                 $getter = 'get' . substr($name, 3);
-                if (is_callable(array($e, $getter))) {
+                if (is_callable([$e, $getter])) {
                     if ($name === 'setParent') {
-                        $value = new MenuItem;
+                        $value = new MenuItem();
                     } else {
                         $value = rand(0, 100);
                     }
@@ -34,27 +32,25 @@ class MenuItemTest extends TestCase
         }
     }
 
-    function testIsAddToMenu()
+    public function testIsAddToMenu()
     {
-        $e = new MenuItem;
-        foreach(array(true, false) as $val) {
+        $e = new MenuItem();
+        foreach ([true, false] as $val) {
             $e->setAddToMenu($val);
             $this->assertEquals($val, $e->isAddToMenu());
         }
     }
 
-
-    function testIsRoot()
+    public function testIsRoot()
     {
-        $e = new MenuItem;
+        $e = new MenuItem();
         $e->setRoot(null);
         $this->assertTrue($e->isRoot());
         $e->setRoot(123);
         $this->assertFalse($e->isRoot());
     }
 
-
-    function testGetLeveledTitle()
+    public function testGetLeveledTitle()
     {
         $e = new MenuItem();
         $e->setTitle('Piet');
@@ -62,11 +58,10 @@ class MenuItemTest extends TestCase
         $this->assertEquals('---Piet', $e->getLeveledTitle());
     }
 
-
-    function testStringRepr()
+    public function testStringRepr()
     {
-        $e = new MenuItem;
+        $e = new MenuItem();
         $e->setTitle('foo');
-        $this->assertEquals('foo', (string) $e);
+        $this->assertEquals('foo', (string)$e);
     }
 }

--- a/tests/Form/Subscriber/MenuItemPersistenceSubscriberTest.php
+++ b/tests/Form/Subscriber/MenuItemPersistenceSubscriberTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * For licensing information, please see the LICENSE file accompanied with this file.
- *
- * @author Gerard van Helden <drm@melp.nl>
- * @copyright 2012 Gerard van Helden <http://melp.nl>
+ * @copyright Zicht Online <http://zicht.nl>
  */
+
 namespace ZichtTest\Bundle\MenuBundle\Manager;
 
 use PHPUnit\Framework\TestCase;
@@ -12,7 +10,7 @@ use Zicht\Bundle\MenuBundle\Form\Subscriber\MenuItemPersistenceSubscriber;
 
 class MenuItemPersistenceSubscriberTest extends TestCase
 {
-    function testSubscribedEvents()
+    public function testSubscribedEvents()
     {
         $mm = $this->getMockBuilder('Zicht\Bundle\MenuBundle\Manager\MenuManager')->disableOriginalConstructor()->getMock();
         $provider = $this->createMock('Zicht\Bundle\UrlBundle\Url\Provider');
@@ -20,7 +18,7 @@ class MenuItemPersistenceSubscriberTest extends TestCase
         $e = new MenuItemPersistenceSubscriber($mm, $provider, $builder);
 
         foreach ($e->getSubscribedEvents() as $type => $method) {
-            $this->assertTrue(is_callable(array($e, $method)));
+            $this->assertTrue(is_callable([$e, $method]));
         }
     }
 }

--- a/tests/Manager/MenuManagerTest.php
+++ b/tests/Manager/MenuManagerTest.php
@@ -1,32 +1,29 @@
 <?php
 /**
- * For licensing information, please see the LICENSE file accompanied with this file.
- *
- * @author Gerard van Helden <drm@melp.nl>
- * @copyright 2012 Gerard van Helden <http://melp.nl>
+ * @copyright Zicht Online <http://zicht.nl>
  */
 
 namespace ZichtTest\Bundle\MenuBundle\Manager;
 
 use PHPUnit\Framework\TestCase;
-use Zicht\Bundle\MenuBundle\Manager\MenuManager;
 use Zicht\Bundle\MenuBundle\Entity\MenuItem;
+use Zicht\Bundle\MenuBundle\Manager\MenuManager;
 
 class MenuManagerTest extends TestCase
 {
-    function testAddItem()
+    public function testAddItem()
     {
-        $doctrine = $this->getMockBuilder('\Doctrine\Bundle\DoctrineBundle\Registry')->disableOriginalConstructor()->setMethods(array('getManager'))->getMock();
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->setMethods(array('persist', 'flush'))->disableOriginalConstructor()->getMock();
+        $doctrine = $this->getMockBuilder('\Doctrine\Bundle\DoctrineBundle\Registry')->disableOriginalConstructor()->setMethods(['getManager'])->getMock();
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->setMethods(['persist', 'flush'])->disableOriginalConstructor()->getMock();
         $doctrine->expects($this->any())->method('getManager')->will($this->returnValue($em));
 
         $mgr = new MenuManager($doctrine);
 
-        $items = array(
+        $items = [
             new MenuItem(),
             new MenuItem(),
-            new MenuItem()
-        );
+            new MenuItem(),
+        ];
 
         $em->expects($this->exactly(count($items)))->method('persist');
         $em->expects($this->once())->method('flush');
@@ -37,25 +34,24 @@ class MenuManagerTest extends TestCase
         $mgr->flush(true);
     }
 
-
-    function testRemoveItem()
+    public function testRemoveItem()
     {
-        $doctrine = $this->getMockBuilder('\Doctrine\Bundle\DoctrineBundle\Registry')->disableOriginalConstructor()->setMethods(array('getManager', 'getManagerForClass'))->getMock();
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->setMethods(array('remove', 'flush'))->disableOriginalConstructor()->getMock();
+        $doctrine = $this->getMockBuilder('\Doctrine\Bundle\DoctrineBundle\Registry')->disableOriginalConstructor()->setMethods(['getManager', 'getManagerForClass'])->getMock();
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->setMethods(['remove', 'flush'])->disableOriginalConstructor()->getMock();
         $doctrine->expects($this->any())->method('getManager')->will($this->returnValue($em));
         $doctrine->expects($this->any())->method('getManagerForClass')->will($this->returnValue(null));
 
         $mgr = new MenuManager($doctrine);
 
-        $items = array(
+        $items = [
             new MenuItem(),
             new MenuItem(),
-            new MenuItem()
-        );
+            new MenuItem(),
+        ];
 
         $em->expects($this->exactly(count($items)))->method('remove');
         $em->expects($this->once())->method('flush');
-        
+
         foreach ($items as $item) {
             $mgr->removeItem($item);
         }


### PR DESCRIPTION
- Removed PHP 7.3 and added PHP 8.1 to the GitHub actions PHP versions matrix.
- Additional cleanup.
- Remove suggests from composer.json